### PR TITLE
Link onlydennis.ca to OnlyDennis

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+onlydennis.ca


### PR DESCRIPTION
Allows us to just use onlydennis.ca instead of friezking.github.io/onlydennis-ca/